### PR TITLE
z3: Add patch to choose correct libdir on x86_64

### DIFF
--- a/z3/lib64.patch
+++ b/z3/lib64.patch
@@ -1,0 +1,11 @@
+--- scripts/mk_util.py	2015-07-03 21:02:50.640972856 -0500
++++ scripts/mk_util.py.new	2015-07-03 21:04:29.524884531 -0500
+@@ -517,7 +517,7 @@
+             STATIC_LIB = True
+         elif not IS_WINDOWS and opt in ('-p', '--prefix'):
+             PREFIX = arg
+-            PYTHON_PACKAGE_DIR = os.path.join(PREFIX, 'lib', 'python%s' % distutils.sysconfig.get_python_version(), 'dist-packages')
++            PYTHON_PACKAGE_DIR = os.path.join(PREFIX, 'lib64', 'python%s' % distutils.sysconfig.get_python_version(), 'dist-packages')
+             mk_dir(PYTHON_PACKAGE_DIR)
+             if sys.version >= "3":
+                 mk_dir(os.path.join(PYTHON_PACKAGE_DIR, '__pycache__'))

--- a/z3/z3.SlackBuild
+++ b/z3/z3.SlackBuild
@@ -65,6 +65,12 @@ mkdir -p $TMP/z3
 cd $TMP/z3
 unzip $CWD/$PRGNAM-cee7dd39444c9060186df79c2a2c7f8845de415b.zip
 chown -R root:root .
+
+# Use correct hard-coded libdir when specifying prefix
+if [ "$LIBDIRSUFFIX" = "64" ]; then
+  patch -p0 < $CWD/lib64.patch
+fi
+
 python scripts/mk_make.py --prefix=$PKG/usr # --prefix=/usr is the default
 cd build
 make


### PR DESCRIPTION
z3's scripts/mk_util.py hard-codes the libdir to $PREFIX/lib/ when --prefix is specified. I had to add this patch to build it on slackware64-current so the python modules would end up in /usr/lib64/.
